### PR TITLE
Add hue property to ShiftConfiguration interface

### DIFF
--- a/src/types/configuration.types.ts
+++ b/src/types/configuration.types.ts
@@ -89,6 +89,7 @@ export type ScaleConfiguration = Record<string, number>
 
 export interface ShiftConfiguration {
   chroma: number
+  hue: number
 }
 
 export type LockedSourceColorsConfiguration = boolean


### PR DESCRIPTION
Introduce a hue property to the ShiftConfiguration interface to enhance color configuration options.